### PR TITLE
Added `PermissionSuggestionProvider` to improve command suggestions

### DIFF
--- a/src/main/java/net/thenextlvl/character/plugin/command/CharacterActionPermissionCommand.java
+++ b/src/main/java/net/thenextlvl/character/plugin/command/CharacterActionPermissionCommand.java
@@ -11,6 +11,7 @@ import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.character.Character;
 import net.thenextlvl.character.plugin.CharacterPlugin;
 import net.thenextlvl.character.plugin.command.suggestion.CharacterWithActionSuggestionProvider;
+import net.thenextlvl.character.plugin.command.suggestion.PermissionSuggestionProvider;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
@@ -34,7 +35,7 @@ class CharacterActionPermissionCommand {
     }
 
     private static ArgumentBuilder<CommandSourceStack, ?> set(CharacterPlugin plugin) {
-        return Commands.literal("set").then(permissionArgument()
+        return Commands.literal("set").then(permissionArgument(plugin)
                 .executes(context -> set(context, plugin)));
     }
 
@@ -64,8 +65,9 @@ class CharacterActionPermissionCommand {
         return success ? Command.SINGLE_SUCCESS : 0;
     }
 
-    private static ArgumentBuilder<CommandSourceStack, ?> permissionArgument() {
-        return Commands.argument("permission", StringArgumentType.string());
+    private static ArgumentBuilder<CommandSourceStack, ?> permissionArgument(CharacterPlugin plugin) {
+        return Commands.argument("permission", StringArgumentType.string())
+                .suggests(new PermissionSuggestionProvider<>(plugin));
     }
 
     private static int set(CommandContext<CommandSourceStack> context, CharacterPlugin plugin) {

--- a/src/main/java/net/thenextlvl/character/plugin/command/suggestion/PermissionSuggestionProvider.java
+++ b/src/main/java/net/thenextlvl/character/plugin/command/suggestion/PermissionSuggestionProvider.java
@@ -1,0 +1,29 @@
+package net.thenextlvl.character.plugin.command.suggestion;
+
+import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+import com.mojang.brigadier.suggestion.Suggestions;
+import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+import net.thenextlvl.character.plugin.CharacterPlugin;
+import org.bukkit.permissions.Permission;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.concurrent.CompletableFuture;
+
+@NullMarked
+public class PermissionSuggestionProvider<T> implements SuggestionProvider<T> {
+    private final CharacterPlugin plugin;
+    
+    public PermissionSuggestionProvider(CharacterPlugin plugin) {
+        this.plugin = plugin;
+    }
+    
+    @Override
+    public CompletableFuture<Suggestions> getSuggestions(CommandContext<T> context, SuggestionsBuilder builder) {
+        plugin.getServer().getPluginManager().getPermissions().stream()
+                .map(Permission::getName)
+                .filter(string -> string.contains(builder.getRemaining()))
+                .forEach(builder::suggest);
+        return builder.buildFuture();
+    }
+}


### PR DESCRIPTION
Introduced a new suggestion provider to filter permissions dynamically based on input. Integrated it into the `permission` argument for `set` commands.