### PR TITLE
Fix rare Key serialization bug

### DIFF
--- a/src/main/java/net/thenextlvl/character/plugin/serialization/KeyAdapter.java
+++ b/src/main/java/net/thenextlvl/character/plugin/serialization/KeyAdapter.java
@@ -20,6 +20,6 @@ public final class KeyAdapter implements TagAdapter<Key> {
 
     @Override
     public Tag serialize(Key key, TagSerializationContext context) throws ParserException {
-        return StringTag.of(key.toString());
+        return StringTag.of(key.asString());
     }
 }


### PR DESCRIPTION
Some implementations of `Key` do not default to `asString` resulting in a wrong or even invalid tag