### PR TITLE
Add view permission message for characters

### DIFF
--- a/src/main/java/net/thenextlvl/character/plugin/command/CharacterViewPermissionCommand.java
+++ b/src/main/java/net/thenextlvl/character/plugin/command/CharacterViewPermissionCommand.java
@@ -41,10 +41,12 @@ final class CharacterViewPermissionCommand extends SimpleCommand {
 
     @Override
     public int run(CommandContext<CommandSourceStack> context) {
-        var character = context.getArgument("character", Character.class);
-        plugin.bundle().sendMessage(context.getSource().getSender(), "character.view-permission",
+        var character = (Character<?>) context.getArgument("character", Character.class);
+        var permission = character.getViewPermission().orElse(null);
+        var message = permission != null ? "character.view-permission" : "character.view-permission.none";
+        plugin.bundle().sendMessage(context.getSource().getSender(), message,
                 Placeholder.unparsed("character", character.getName()),
-                Placeholder.unparsed("permission", String.valueOf(character.getViewPermission())));
+                Placeholder.unparsed("permission", String.valueOf(permission)));
         return SINGLE_SUCCESS;
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -59,6 +59,7 @@ character.tag.text=<gray><prefix> Set <green><character>'s</green> name tag to <
 character.tag.visible=<gray><prefix> <green><character>'s</green> name tag is now visible</gray>
 character.teleported.self=<gray><prefix> You got teleported to <green><character></green></gray>
 character.teleported=<gray><prefix> Teleported <green><character></green> to <green><world>, <x:#.###>, <y:#.###>, <z:#.###></green> [<green><yaw:#.#>, <pitch:#.#></green>]</gray>
+character.view-permission.none=<gray><prefix> No permission required to see <green><character></green></gray>
 character.view-permission.removed=<gray><prefix> Removed view-permission from <green><character></green></gray>
 character.view-permission.set=<gray><prefix> Set view-permission of <green><character></green> to <green><permission></green></gray>
 character.view-permission=<gray><prefix> The view-permission of <green><character></green> is <green><permission></green></gray>

--- a/src/main/resources/messages_german.properties
+++ b/src/main/resources/messages_german.properties
@@ -59,6 +59,7 @@ character.tag.text=<gray><prefix> <green><character>'s</green> Namensschildtext 
 character.tag.visible=<gray><prefix> <green><character>'s</green> Namensschild ist jetzt sichtbar</gray>
 character.teleported.self=<gray><prefix> Du wurdest zu <green><character></green> teleportiert</gray>
 character.teleported=<gray><prefix> <green><character></green> wurde zu <green><world>, <x:#.###>, <y:#.###>, <z:#.###></green> [<green><yaw:#.#>, <pitch:#.#></green>] teleportiert</gray>
+character.view-permission.none=<gray><prefix> Es wird keine Berechtigung benötigt um <green><character></green> zu sehen</gray>
 character.view-permission.removed=<gray><prefix> Die Ansichtsberechtigung von <green><character></green> wurde entfernt</gray>
 character.view-permission.set=<gray><prefix> Die Ansichtsberechtigung von <green><character></green> ist jetzt <green><permission></green></gray>
 command.sender=<red><prefix> Du darfst dieses Kommando nicht nutzen</red>


### PR DESCRIPTION
Enhance character view permission handling by adding a message for cases where no permission is required to view a character. Update related properties in both English and German message files.